### PR TITLE
79: tim - suggested changes

### DIFF
--- a/next/app/layout.tsx
+++ b/next/app/layout.tsx
@@ -2,7 +2,6 @@ import { auth } from "@/auth";
 import type { Metadata } from "next";
 import "./globals.css";
 import { Header } from "./lib/components";
-import { SessionProvider } from "next-auth/react";
 
 export const metadata: Metadata = {
   title: "ZEVA",
@@ -19,12 +18,10 @@ export default async function RootLayout({
     // Authenticated layout
     return (
       <html lang="en">
-        <SessionProvider session={session}>
-          <body className="antialiased h-screen flex flex-col">
-            <Header session={session} />
-            <main className="flex-1 overflow-auto">{children}</main>
-          </body>
-        </SessionProvider>
+        <body className="antialiased h-screen flex flex-col">
+          <Header session={session} />
+          <main className="flex-1 overflow-auto">{children}</main>
+        </body>
       </html>
     );
   } else {

--- a/next/app/vehicle/lib/actions.ts
+++ b/next/app/vehicle/lib/actions.ts
@@ -1,17 +1,31 @@
 "use server";
 
+import { getUserInfo } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
-export async function createVehicleComment(
-  vehicleId: number,
-  comment: string,
-  userId: number,
-) {
-  return await prisma.vehicleComment.create({
-    data: {
-      comment,
-      vehicle: { connect: { id: vehicleId } },
-      createUser: { connect: { id: userId } },
-    },
-  });
+export async function createVehicleComment(vehicleId: number, comment: string) {
+  const { userIsGov, userId, userOrgId } = await getUserInfo();
+  const createComment = async () => {
+    return await prisma.vehicleComment.create({
+      data: {
+        comment,
+        vehicleId,
+        createUserId: userId,
+      },
+    });
+  };
+  // not sure about this logic; may need to change it later;
+  // maybe adding vehicle comments is just for gov users?
+  if (comment) {
+    if (userIsGov) {
+      createComment();
+    } else {
+      const vehicle = await prisma.vehicle.findUnique({
+        where: { id: vehicleId },
+      });
+      if (vehicle && vehicle.organizationId === userOrgId) {
+        createComment();
+      }
+    }
+  }
 }

--- a/next/app/vehicle/lib/components/CommentInput.tsx
+++ b/next/app/vehicle/lib/components/CommentInput.tsx
@@ -2,20 +2,17 @@
 
 import { useState, useTransition } from "react";
 import { createVehicleComment } from "../actions";
-import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
 export default function CommentInput({ vehicleId }: { vehicleId: number }) {
   const [comment, setComment] = useState("");
   const [isPending, startTransition] = useTransition();
-  const { data: session } = useSession();
-  const userId = session?.user?.internalId;
   const router = useRouter();
   const handleSubmit = () => {
-    if (!userId || !comment.trim()) return;
-    startTransition(() => {
-      createVehicleComment(vehicleId, comment, userId);
+    if (!comment.trim()) return;
+    startTransition(async () => {
       setComment("");
+      await createVehicleComment(vehicleId, comment);
       router.refresh();
     });
   };

--- a/next/app/vehicle/lib/components/VehicleTable.tsx
+++ b/next/app/vehicle/lib/components/VehicleTable.tsx
@@ -10,7 +10,6 @@ export const VehicleTable = (props: {
   totalNumbeOfVehicles: number;
   navigationAction: (id: number) => Promise<void>;
 }) => {
-  console.log(props.vehicles);
   const columnHelper = createColumnHelper<VehicleSparseSerialized>();
 
   const columns = useMemo(() => {


### PR DESCRIPTION

Looks good! Just a few things: next-auth actually recommends that we do authentication server side: “Although next-auth supports client-side data retrieval using useSession and SessionProvider for both the App Router and Pages Router, in real-world scenarios, these are used less frequently. Typically, you’ll want to take full advantage of server-side rendering to optimize performance and security” (https://authjs.dev/getting-started/session-management/get-session). 

I think it may be because `useSession` creates additional calls to the backend, since the user’s session cookie is encrypted and only the server has the decryption key, so the client needs to call the backend to get the decrypted session details. So I removed the `SessionProvider` and `useSession` stuff.

Also, the `createVehicleComment` action is a server action, which means it’s exposed to the incoming requests. Since that’s the case, you’ll want to do some authentication checks within that action (even if you do client-side checks!). 